### PR TITLE
feat: set time encoder to RFC3339

### DIFF
--- a/zap/config.go
+++ b/zap/config.go
@@ -1,7 +1,14 @@
 package zap
 
 import (
+	"time"
+
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	timeKey = "time"
 )
 
 // Config contains a subset of the zap configuration.
@@ -21,6 +28,9 @@ type Config struct {
 	// "console", as well as any third-party encodings registered via
 	// RegisterEncoder.
 	Encoding string `json:"encoding"`
+	// EncoderConfig sets options for the chosen encoder. See
+	// zapcore.EncoderConfig for details.
+	EncoderConfig zapcore.EncoderConfig `json:"encoderConfig"`
 	// OutputPaths is a list of URLs or file paths to write logging output to.
 	// See Open for details.
 	OutputPaths []string `json:"output_paths"`
@@ -59,4 +69,11 @@ func prepareConfig(src Config, dest *zap.Config) error {
 	}
 
 	return nil
+}
+
+func setTimeEncoder(c *zap.Config) {
+	c.EncoderConfig.TimeKey = timeKey
+	c.EncoderConfig.EncodeTime = func(t time.Time, encoder zapcore.PrimitiveArrayEncoder) {
+		encoder.AppendString(t.UTC().Format(time.RFC3339))
+	}
 }

--- a/zap/logger.go
+++ b/zap/logger.go
@@ -11,6 +11,8 @@ import (
 // CreateLogger is a wrapping constructor which produces zap.Logger in a customised form based on provided config.
 func CreateLogger(config Config) (*zap.Logger, error) {
 	c := zap.NewProductionConfig()
+
+	setTimeEncoder(&c)
 	if err := prepareConfig(config, &c); err != nil {
 		return nil, fmt.Errorf("preparing config: %w", err)
 	}

--- a/zap/logger_dev.go
+++ b/zap/logger_dev.go
@@ -17,6 +17,7 @@ func CreateLogger(config Config) (*zap.Logger, error) {
 
 	c := zap.NewDevelopmentConfig()
 	c.EncoderConfig = ec
+	setTimeEncoder(&c)
 
 	if err := prepareConfig(config, &c); err != nil {
 		return nil, fmt.Errorf("preparing config: %w", err)


### PR DESCRIPTION
Example of log:
`{"level":"info","time":"2022-07-25T18:10:46.945545Z","msg":"server started","caller":"httpx.Server"}`